### PR TITLE
Change build-image licenses to Apache

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,15 +1,13 @@
-Copyright (C) 2016  Microsoft
+Copyright (C) 2023  Microsoft
 
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION

#### Why I did it
After consulting with MSFT team, Sonic-build image licenses should be "Apache" as all submodules licenses

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change LICENSE file

#### How to verify it



#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x ] 202205
- [x ] 202211



#### A picture of a cute animal (not mandatory but encouraged)

